### PR TITLE
fixed syntax error on line 230

### DIFF
--- a/include/talleo_payments.php
+++ b/include/talleo_payments.php
@@ -227,7 +227,7 @@ class Talleo_Gateway extends WC_Payment_Gateway {
             $icon = "talleo_icon_large.png";
         } else {
             $color = "DC143C";
-            $icon = "loader.gif"
+            $icon = "loader.gif";
         }
 
         if($this->discount) {


### PR DESCRIPTION
For some reason, there is a syntax error in include/talleo_payments.php:230. 
It appears the terminating semicolon was missing at the end of the line;

![test1](https://user-images.githubusercontent.com/15680083/114619951-95f9ba00-9c9a-11eb-86a4-e825ae8de72c.PNG)
